### PR TITLE
Eperez change password 162

### DIFF
--- a/eduiddashboard/templates/passwords-form-js.jinja2
+++ b/eduiddashboard/templates/passwords-form-js.jinja2
@@ -64,9 +64,14 @@
 
             body.off('form-submitted');
             body.on('form-submitted', function () {
-                $('div#changePasswordDialog div.alert').removeClass('fixed');
-                $('body').trigger('action-executed');
-                $('div#changePasswordDialog a.close').click();
+                msg_area = pwdialog.find('div.alert');
+                if (msg_area.hasClass('alert-error')) {
+                    msg_area.addClass('fixed');
+                } else {
+                    msg_area.removeClass('fixed');
+                    $('body').trigger('action-executed');
+                    pwdialog.find('a.close').click();
+                }
             });
 
             $.each(events, function (i, o) {


### PR DESCRIPTION
This is for EDUID-162:
https://project.nordu.net/browse/EDUID-162

The solution is not exactly as indicated in the description of the issue above. All I'm doing is closing the dialog and putting any success message (e.g. "Your password has been successfully updated") in the general notification area (outsifde the dialog). If there are errors in the form (e.g. the old password is wrong), the dialog stays and the behaviour does not change. 
