### PR TITLE
Eperez wizard validation

### DIFF
--- a/eduiddashboard/locale/eduid-dashboard.pot
+++ b/eduiddashboard/locale/eduid-dashboard.pot
@@ -7,9 +7,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: eduid-dashboard 0.3.11b1\n"
+"Project-Id-Version: eduid-dashboard 0.3.11\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-01 10:24+0200\n"
+"POT-Creation-Date: 2015-07-10 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Reset your {site_name} password"
 msgstr ""
 
-#: eduiddashboard/models.py:22 eduiddashboard/models.py:95
+#: eduiddashboard/models.py:22 eduiddashboard/models.py:96
 #: eduiddashboard/views/security.py:395
 msgid "email"
 msgstr ""
@@ -43,109 +43,109 @@ msgstr ""
 msgid "national identity number"
 msgstr ""
 
-#: eduiddashboard/models.py:97
+#: eduiddashboard/models.py:98
 msgid "Email address"
 msgstr ""
 
-#: eduiddashboard/models.py:104
+#: eduiddashboard/models.py:105
 msgid "The Swedish national identity number should be entered as yyyymmddnnnn"
 msgstr ""
 
-#: eduiddashboard/models.py:109
+#: eduiddashboard/models.py:110
 msgid ""
 "Invalid telephone number. It must be a valid Swedish number, or written using"
 " international notation, starting with \"+\" and followed by 10-20 digits."
 msgstr ""
 
-#: eduiddashboard/models.py:154
+#: eduiddashboard/models.py:155
 msgid "Swedish national identity number"
 msgstr ""
 
-#: eduiddashboard/models.py:156
+#: eduiddashboard/models.py:157
 #: eduiddashboard/templates/wizards/wizard-norEduPersonNIN.jinja2:14
 msgid "yyyymmddnnnn"
 msgstr ""
 
-#: eduiddashboard/models.py:175
+#: eduiddashboard/models.py:176
 msgid "Given name"
 msgstr ""
 
-#: eduiddashboard/models.py:180 eduiddashboard/templates/home.jinja2:29
+#: eduiddashboard/models.py:181 eduiddashboard/templates/home.jinja2:29
 msgid "Surname"
 msgstr ""
 
-#: eduiddashboard/models.py:185
+#: eduiddashboard/models.py:186
 msgid "Display name"
 msgstr ""
 
-#: eduiddashboard/models.py:187
+#: eduiddashboard/models.py:188
 msgid "Preferred language"
 msgstr ""
 
-#: eduiddashboard/models.py:202
+#: eduiddashboard/models.py:203
 msgid "Current password"
 msgstr ""
 
-#: eduiddashboard/models.py:211 eduiddashboard/models.py:280
+#: eduiddashboard/models.py:212 eduiddashboard/models.py:281
 msgid "Use my own password"
 msgstr ""
 
-#: eduiddashboard/models.py:216 eduiddashboard/models.py:285
+#: eduiddashboard/models.py:217 eduiddashboard/models.py:286
 msgid "Suggested password"
 msgstr ""
 
-#: eduiddashboard/models.py:225
+#: eduiddashboard/models.py:226
 msgid "Custom password"
 msgstr ""
 
-#: eduiddashboard/models.py:235
+#: eduiddashboard/models.py:236
 msgid "Repeat the password"
 msgstr ""
 
-#: eduiddashboard/models.py:299
+#: eduiddashboard/models.py:300
 msgid "New Password"
 msgstr ""
 
-#: eduiddashboard/models.py:306
+#: eduiddashboard/models.py:307
 msgid "Confirm New Password"
 msgstr ""
 
-#: eduiddashboard/models.py:312
+#: eduiddashboard/models.py:313
 msgid "Passwords doesn't match"
 msgstr ""
 
-#: eduiddashboard/models.py:324
+#: eduiddashboard/models.py:325
 #: eduiddashboard/templates/postaladdress-form.jinja2:22
 msgid "Address"
 msgstr ""
 
-#: eduiddashboard/models.py:330
+#: eduiddashboard/models.py:331
 #: eduiddashboard/templates/postaladdress-form.jinja2:29
 msgid "City"
 msgstr ""
 
-#: eduiddashboard/models.py:336
+#: eduiddashboard/models.py:337
 msgid "Postal code"
 msgstr ""
 
-#: eduiddashboard/models.py:342
+#: eduiddashboard/models.py:343
 #: eduiddashboard/templates/postaladdress-form.jinja2:43
 msgid "Country"
 msgstr ""
 
-#: eduiddashboard/models.py:355
+#: eduiddashboard/models.py:356
 msgid "mobile"
 msgstr ""
 
-#: eduiddashboard/models.py:357
+#: eduiddashboard/models.py:358
 msgid "Mobile phone number"
 msgstr ""
 
-#: eduiddashboard/models.py:373 eduiddashboard/templates/home.jinja2:17
+#: eduiddashboard/models.py:374 eduiddashboard/templates/home.jinja2:17
 msgid "Search for users"
 msgstr ""
 
-#: eduiddashboard/models.py:374
+#: eduiddashboard/models.py:375
 msgid "query"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid ""
 "If you do not have a record in the Swedish population register\n"
 "      or if you live somewhere Else you may manually add a postal address by\n"
-"      clicking on the button below. If you are registered please click\n"
+"      clikcing on the button below. If you are registered please click\n"
 "      <a href=\"#nins\">here</a> to enter your national identity number to\n"
 "      automatically fetch your postal address.\n"
 "    "
@@ -1329,29 +1329,33 @@ msgstr ""
 msgid "No pending national identity numbers found."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:376
+#: eduiddashboard/views/nins.py:379
 msgid "User data out of sync. Please try again."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:378
+#: eduiddashboard/views/nins.py:381
 msgid "Your national identity number has been confirmed"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:390
+#: eduiddashboard/views/nins.py:393
 msgid ""
 "A confirmation code has been sent to your government inbox. Please click on "
 "\"Pending confirmation\" link below to enter your confirmation code."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:437
+#: eduiddashboard/views/nins.py:440
 msgid "Add NIN with MM confirmation"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:442
+#: eduiddashboard/views/nins.py:445
 msgid "Your national identity number confirmation request can not be found"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:463
+#: eduiddashboard/views/nins.py:464
+msgid "There was an unknown error dealing with your request"
+msgstr ""
+
+#: eduiddashboard/views/nins.py:484
 msgid "Add your national identity number"
 msgstr ""
 

--- a/eduiddashboard/locale/en/LC_MESSAGES/eduid-dashboard.po
+++ b/eduiddashboard/locale/en/LC_MESSAGES/eduid-dashboard.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eduid-dashboard 0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-01 10:24+0200\n"
+"POT-Creation-Date: 2015-07-10 13:17+0200\n"
 "PO-Revision-Date: 2013-11-22 09:46+0100\n"
 "Last-Translator: Fredrik Thulin <fredrik@thulin.net>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Reset your {site_name} password"
 msgstr ""
 
-#: eduiddashboard/models.py:22 eduiddashboard/models.py:95
+#: eduiddashboard/models.py:22 eduiddashboard/models.py:96
 #: eduiddashboard/views/security.py:395
 msgid "email"
 msgstr ""
@@ -43,110 +43,110 @@ msgstr ""
 msgid "national identity number"
 msgstr ""
 
-#: eduiddashboard/models.py:97
+#: eduiddashboard/models.py:98
 msgid "Email address"
 msgstr ""
 
-#: eduiddashboard/models.py:104
+#: eduiddashboard/models.py:105
 msgid "The Swedish national identity number should be entered as yyyymmddnnnn"
 msgstr ""
 
-#: eduiddashboard/models.py:109
+#: eduiddashboard/models.py:110
 msgid ""
 "Invalid telephone number. It must be a valid Swedish number, or written "
 "using international notation, starting with \"+\" and followed by 10-20 "
 "digits."
 msgstr ""
 
-#: eduiddashboard/models.py:154
+#: eduiddashboard/models.py:155
 msgid "Swedish national identity number"
 msgstr ""
 
-#: eduiddashboard/models.py:156
+#: eduiddashboard/models.py:157
 #: eduiddashboard/templates/wizards/wizard-norEduPersonNIN.jinja2:14
 msgid "yyyymmddnnnn"
 msgstr ""
 
-#: eduiddashboard/models.py:175
+#: eduiddashboard/models.py:176
 msgid "Given name"
 msgstr ""
 
-#: eduiddashboard/models.py:180 eduiddashboard/templates/home.jinja2:29
+#: eduiddashboard/models.py:181 eduiddashboard/templates/home.jinja2:29
 msgid "Surname"
 msgstr ""
 
-#: eduiddashboard/models.py:185
+#: eduiddashboard/models.py:186
 msgid "Display name"
 msgstr ""
 
-#: eduiddashboard/models.py:187
+#: eduiddashboard/models.py:188
 msgid "Preferred language"
 msgstr ""
 
-#: eduiddashboard/models.py:202
+#: eduiddashboard/models.py:203
 msgid "Current password"
 msgstr ""
 
-#: eduiddashboard/models.py:211 eduiddashboard/models.py:280
+#: eduiddashboard/models.py:212 eduiddashboard/models.py:281
 msgid "Use my own password"
 msgstr ""
 
-#: eduiddashboard/models.py:216 eduiddashboard/models.py:285
+#: eduiddashboard/models.py:217 eduiddashboard/models.py:286
 msgid "Suggested password"
 msgstr ""
 
-#: eduiddashboard/models.py:225
+#: eduiddashboard/models.py:226
 msgid "Custom password"
 msgstr ""
 
-#: eduiddashboard/models.py:235
+#: eduiddashboard/models.py:236
 msgid "Repeat the password"
 msgstr ""
 
-#: eduiddashboard/models.py:299
+#: eduiddashboard/models.py:300
 msgid "New Password"
 msgstr ""
 
-#: eduiddashboard/models.py:306
+#: eduiddashboard/models.py:307
 msgid "Confirm New Password"
 msgstr ""
 
-#: eduiddashboard/models.py:312
+#: eduiddashboard/models.py:313
 msgid "Passwords doesn't match"
 msgstr ""
 
-#: eduiddashboard/models.py:324
+#: eduiddashboard/models.py:325
 #: eduiddashboard/templates/postaladdress-form.jinja2:22
 msgid "Address"
 msgstr ""
 
-#: eduiddashboard/models.py:330
+#: eduiddashboard/models.py:331
 #: eduiddashboard/templates/postaladdress-form.jinja2:29
 msgid "City"
 msgstr ""
 
-#: eduiddashboard/models.py:336
+#: eduiddashboard/models.py:337
 msgid "Postal code"
 msgstr ""
 
-#: eduiddashboard/models.py:342
+#: eduiddashboard/models.py:343
 #: eduiddashboard/templates/postaladdress-form.jinja2:43
 msgid "Country"
 msgstr ""
 
-#: eduiddashboard/models.py:355
+#: eduiddashboard/models.py:356
 msgid "mobile"
 msgstr ""
 
-#: eduiddashboard/models.py:357
+#: eduiddashboard/models.py:358
 msgid "Mobile phone number"
 msgstr ""
 
-#: eduiddashboard/models.py:373 eduiddashboard/templates/home.jinja2:17
+#: eduiddashboard/models.py:374 eduiddashboard/templates/home.jinja2:17
 msgid "Search for users"
 msgstr ""
 
-#: eduiddashboard/models.py:374
+#: eduiddashboard/models.py:375
 msgid "query"
 msgstr ""
 
@@ -778,7 +778,7 @@ msgid ""
 "If you do not have a record in the Swedish population register\n"
 "      or if you live somewhere Else you may manually add a postal address"
 " by\n"
-"      clicking on the button below. If you are registered please click\n"
+"      clikcing on the button below. If you are registered please click\n"
 "      <a href=\"#nins\">here</a> to enter your national identity number "
 "to\n"
 "      automatically fetch your postal address.\n"
@@ -1345,29 +1345,33 @@ msgstr ""
 msgid "No pending national identity numbers found."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:376
+#: eduiddashboard/views/nins.py:379
 msgid "User data out of sync. Please try again."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:378
+#: eduiddashboard/views/nins.py:381
 msgid "Your national identity number has been confirmed"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:390
+#: eduiddashboard/views/nins.py:393
 msgid ""
 "A confirmation code has been sent to your government inbox. Please click "
 "on \"Pending confirmation\" link below to enter your confirmation code."
 msgstr ""
 
-#: eduiddashboard/views/nins.py:437
+#: eduiddashboard/views/nins.py:440
 msgid "Add NIN with MM confirmation"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:442
+#: eduiddashboard/views/nins.py:445
 msgid "Your national identity number confirmation request can not be found"
 msgstr ""
 
-#: eduiddashboard/views/nins.py:463
+#: eduiddashboard/views/nins.py:464
+msgid "There was an unknown error dealing with your request"
+msgstr ""
+
+#: eduiddashboard/views/nins.py:484
 msgid "Add your national identity number"
 msgstr ""
 
@@ -2014,7 +2018,7 @@ msgstr ""
 #~ "      or if you live somewhere "
 #~ "Else you may manually add a postal"
 #~ " address by\n"
-#~ "      clikcing on the button below. "
+#~ "      clicking on the button below. "
 #~ "If you are registered please click\n"
 #~ ""
 #~ "      <a href=\"#nins\">here</a> to enter "

--- a/eduiddashboard/locale/sv/LC_MESSAGES/eduid-dashboard.po
+++ b/eduiddashboard/locale/sv/LC_MESSAGES/eduid-dashboard.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  eduid-dashboard\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2015-06-01 10:24+0200\n"
+"POT-Creation-Date: 2015-07-10 13:17+0200\n"
 "PO-Revision-Date: 2015-06-03 10:23+0000\n"
 "Last-Translator: Gijutsu <ascii@binary.to>\n"
 "Language-Team: Swedish (http://www.transifex.com/projects/p/eduid-"
@@ -35,7 +35,7 @@ msgstr "{site_name} kontoborttagning"
 msgid "Reset your {site_name} password"
 msgstr "Återställning av ditt {site_name} lösenord"
 
-#: eduiddashboard/models.py:22 eduiddashboard/models.py:95
+#: eduiddashboard/models.py:22 eduiddashboard/models.py:96
 #: eduiddashboard/views/security.py:395
 msgid "email"
 msgstr "e-post"
@@ -48,15 +48,15 @@ msgstr "mobiltelefonnummer"
 msgid "national identity number"
 msgstr "personnummer"
 
-#: eduiddashboard/models.py:97
+#: eduiddashboard/models.py:98
 msgid "Email address"
 msgstr "E-postadress"
 
-#: eduiddashboard/models.py:104
+#: eduiddashboard/models.py:105
 msgid "The Swedish national identity number should be entered as yyyymmddnnnn"
 msgstr "Ange personnummer som ååååmmddnnnn"
 
-#: eduiddashboard/models.py:109
+#: eduiddashboard/models.py:110
 msgid ""
 "Invalid telephone number. It must be a valid Swedish number, or written "
 "using international notation, starting with \"+\" and followed by 10-20 "
@@ -65,95 +65,95 @@ msgstr ""
 "Felaktigt telefonnummer. Telefonnumret måste börja med \"+\" följt av "
 "10-20 siffror."
 
-#: eduiddashboard/models.py:154
+#: eduiddashboard/models.py:155
 msgid "Swedish national identity number"
 msgstr "Personnummer"
 
-#: eduiddashboard/models.py:156
+#: eduiddashboard/models.py:157
 #: eduiddashboard/templates/wizards/wizard-norEduPersonNIN.jinja2:14
 msgid "yyyymmddnnnn"
 msgstr "ååååmmddnnnn"
 
-#: eduiddashboard/models.py:175
+#: eduiddashboard/models.py:176
 msgid "Given name"
 msgstr "Förnamn"
 
-#: eduiddashboard/models.py:180 eduiddashboard/templates/home.jinja2:29
+#: eduiddashboard/models.py:181 eduiddashboard/templates/home.jinja2:29
 msgid "Surname"
 msgstr "Efternamn"
 
-#: eduiddashboard/models.py:185
+#: eduiddashboard/models.py:186
 msgid "Display name"
 msgstr "Visningsnamn"
 
-#: eduiddashboard/models.py:187
+#: eduiddashboard/models.py:188
 msgid "Preferred language"
 msgstr "Språk"
 
-#: eduiddashboard/models.py:202
+#: eduiddashboard/models.py:203
 msgid "Current password"
 msgstr "Nuvarande lösenord"
 
-#: eduiddashboard/models.py:211 eduiddashboard/models.py:280
+#: eduiddashboard/models.py:212 eduiddashboard/models.py:281
 msgid "Use my own password"
 msgstr "Välj lösenord själv"
 
-#: eduiddashboard/models.py:216 eduiddashboard/models.py:285
+#: eduiddashboard/models.py:217 eduiddashboard/models.py:286
 msgid "Suggested password"
 msgstr "Rekommenderat lösenord"
 
-#: eduiddashboard/models.py:225
+#: eduiddashboard/models.py:226
 msgid "Custom password"
 msgstr "Valt lösenord"
 
-#: eduiddashboard/models.py:235
+#: eduiddashboard/models.py:236
 msgid "Repeat the password"
 msgstr "Repetera valt lösenord"
 
-#: eduiddashboard/models.py:299
+#: eduiddashboard/models.py:300
 msgid "New Password"
 msgstr "Nytt lösenord"
 
-#: eduiddashboard/models.py:306
+#: eduiddashboard/models.py:307
 msgid "Confirm New Password"
 msgstr "Bekräfta nytt lösenord"
 
-#: eduiddashboard/models.py:312
+#: eduiddashboard/models.py:313
 msgid "Passwords doesn't match"
 msgstr "Lösenorden är olika"
 
-#: eduiddashboard/models.py:324
+#: eduiddashboard/models.py:325
 #: eduiddashboard/templates/postaladdress-form.jinja2:22
 msgid "Address"
 msgstr "Adress"
 
-#: eduiddashboard/models.py:330
+#: eduiddashboard/models.py:331
 #: eduiddashboard/templates/postaladdress-form.jinja2:29
 msgid "City"
 msgstr "Stad"
 
-#: eduiddashboard/models.py:336
+#: eduiddashboard/models.py:337
 msgid "Postal code"
 msgstr "Postkod"
 
-#: eduiddashboard/models.py:342
+#: eduiddashboard/models.py:343
 #: eduiddashboard/templates/postaladdress-form.jinja2:43
 msgid "Country"
 msgstr "Land"
 
-#: eduiddashboard/models.py:355
+#: eduiddashboard/models.py:356
 msgid "mobile"
 msgstr "mobiltelefon"
 
-#: eduiddashboard/models.py:357
+#: eduiddashboard/models.py:358
 msgid "Mobile phone number"
 msgstr "Mobiltelefonnummer"
 
-#: eduiddashboard/models.py:373 eduiddashboard/templates/home.jinja2:17
+#: eduiddashboard/models.py:374 eduiddashboard/templates/home.jinja2:17
 msgid "Search for users"
 msgstr "Sök efter användare"
 
-#: eduiddashboard/models.py:374
+#: eduiddashboard/models.py:375
 msgid "query"
 msgstr "sökfras"
 
@@ -873,7 +873,7 @@ msgid ""
 "If you do not have a record in the Swedish population register\n"
 "      or if you live somewhere Else you may manually add a postal address"
 " by\n"
-"      clicking on the button below. If you are registered please click\n"
+"      clikcing on the button below. If you are registered please click\n"
 "      <a href=\"#nins\">here</a> to enter your national identity number "
 "to\n"
 "      automatically fetch your postal address.\n"
@@ -1574,15 +1574,15 @@ msgstr "Personnumret har tagits bort"
 msgid "No pending national identity numbers found."
 msgstr "Det finns inga personnummer som behöver bekräftas."
 
-#: eduiddashboard/views/nins.py:376
+#: eduiddashboard/views/nins.py:379
 msgid "User data out of sync. Please try again."
 msgstr "Ditt användardata har ändrats från en annan dashboard. Försök igen."
 
-#: eduiddashboard/views/nins.py:378
+#: eduiddashboard/views/nins.py:381
 msgid "Your national identity number has been confirmed"
 msgstr "Ditt personnummer är bekräftat"
 
-#: eduiddashboard/views/nins.py:390
+#: eduiddashboard/views/nins.py:393
 msgid ""
 "A confirmation code has been sent to your government inbox. Please click "
 "on \"Pending confirmation\" link below to enter your confirmation code."
@@ -1591,15 +1591,19 @@ msgstr ""
 "myndighetspost\". Vänligen ange din bekräftelsekod genom att klicka på "
 "\"Bekräfta\" här nedan."
 
-#: eduiddashboard/views/nins.py:437
+#: eduiddashboard/views/nins.py:440
 msgid "Add NIN with MM confirmation"
 msgstr "Lägg till personnummer med MM bekräftelse"
 
-#: eduiddashboard/views/nins.py:442
+#: eduiddashboard/views/nins.py:445
 msgid "Your national identity number confirmation request can not be found"
 msgstr "Kan ej hitta en bekräftelseförfrågan för ditt personnummer "
 
-#: eduiddashboard/views/nins.py:463
+#: eduiddashboard/views/nins.py:464
+msgid "There was an unknown error dealing with your request"
+msgstr ""
+
+#: eduiddashboard/views/nins.py:484
 msgid "Add your national identity number"
 msgstr "Lägg till ditt personnummer"
 
@@ -1665,4 +1669,18 @@ msgstr "Välj ett nytt lösenord för ditt eduID konto."
 #: eduiddashboard/views/verifications.py:27
 msgid "Can't locate the code in the active session"
 msgstr "Kan inte hitta koden i den aktiva sessionen"
+
+#~ msgid ""
+#~ "If you do not have a record in the Swedish population register\n"
+#~ "      or if you live somewhere "
+#~ "Else you may manually add a postal"
+#~ " address by\n"
+#~ "      clicking on the button below. "
+#~ "If you are registered please click\n"
+#~ ""
+#~ "      <a href=\"#nins\">here</a> to enter "
+#~ "your national identity number to\n"
+#~ "      automatically fetch your postal address.\n"
+#~ "    "
+#~ msgstr ""
 

--- a/eduiddashboard/models.py
+++ b/eduiddashboard/models.py
@@ -77,14 +77,15 @@ class All_StopOnFirst_Switch(object):
     def __call__(self, node, value):
         request = node.bindings.get('request')
 
-        for key in self.validator_dict.keys():
-            if key in request.POST:
-                current_validator = self.validator_dict[key]
-                for validator in current_validator.validators:
-                    try:
-                        validator(node, value)
-                    except colander.Invalid as e:
-                        raise colander.Invalid(node, e.msg)
+        if 'add_by_mobile' in request.POST:
+            current_validator = self.validator_dict['add_by_mobile']
+        else:
+            current_validator = self.validator_dict['add']
+            for validator in current_validator.validators:
+                try:
+                    validator(node, value)
+                except colander.Invalid as e:
+                    raise colander.Invalid(node, e.msg)
 
 
 class Email(CSRFTokenSchema):


### PR DESCRIPTION
In an email from Johan Lundberg:

First a secondary problem that needs fixing in the wizard code, it
seems that when trying to verify a NIN using the wizard the
is_reachable check is not done before trying to send a message to
Minameddelanden. This would keep users from adding incorrect formatted
NINS or NINs with no Minameddelande-inbox to the verifications database.

If the above problem is fixed a user would still be able to trigger a
is_reachable request (now it's a send_message request) with an
incorrect NIN as the resend link in step 2 of the wizard does not seem
to validate the NIN string set in step 1. Using the Next button from
step 1 will clean the NIN string though.