### PR TITLE
Remove dependency on html5.js (that we fetched over http)

### DIFF
--- a/eduiddashboard/templates/base.jinja2
+++ b/eduiddashboard/templates/base.jinja2
@@ -6,10 +6,6 @@
     <title>{{ _("Dashboard") }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!--[if lt IE 9]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <link href="{{'eduiddashboard:static/css/bootstrap-3.2.0.min.css'|static_url}}" rel="stylesheet" media="screen">
     <link href="{{'eduiddashboard:static/css/dashboard.css'|static_url}}" rel="stylesheet" media="screen">


### PR DESCRIPTION
since we do not support anything less than IE9 in our cipher setting anyway,
we can remove this external dependency.