### PR TITLE
Fixed regression in nins-form.jinja2 to only display the verified NIN

### DIFF
--- a/eduiddashboard/templates/nins-form.jinja2
+++ b/eduiddashboard/templates/nins-form.jinja2
@@ -19,31 +19,32 @@
             <td class='non-identifier'><span class='nobutton'>{{_("Active")}}</span></td>
             <td class='non-identifier'></td>
         </tr>
-    {% endif %}
-    {% if not_verified_nins %}
-      {% for nin in not_verified_nins %}
-      <tr class='ninrow' data-identifier="{{ loop.index0 }}">
-          <td class='identifier'>{{ nin }}</td>
-          <td class='non-identifier'>
-            {% if enable_mm_verification %}
-            <input type='button' class='btn btn-link' value="{{_('Verify through Mina Meddelanden')}}"
-                 data-index='{{ nin }} {{ loop.index0 }}' name='verify'>
-            {% endif %}
-          </td>
-          <td class='non-identifier'>
-            {% if has_mobile %}
-            <input type='button' class='btn btn-link verify_mb' value="{{_('Verify by registered phone')}}"
-                 data-index='{{ nin }} {{ loop.index0 }}' name='verify_mb'>
-            {% endif %}
-          </td>
-          <!-- Removed functionality temporary
-                      <td>
-                        <input type='button' class='btn btn-link' value="{{_('Remove')}}"
-                             data-index='{{ nin }} {{ loop.index0 }}' name='remove'>
-                      </td>
-                     -->
-      </tr>
-      {% endfor %}
+    {% else %}
+        {% if not_verified_nins %}
+            {% for nin in not_verified_nins %}
+                <tr class='ninrow' data-identifier="{{ loop.index0 }}">
+                    <td class='identifier'>{{ nin }}</td>
+                    <td class='non-identifier'>
+                        {% if enable_mm_verification %}
+                            <input type='button' class='btn btn-link' value="{{_('Verify through Mina Meddelanden')}}"
+                                   data-index='{{ nin }} {{ loop.index0 }}' name='verify'>
+                        {% endif %}
+                    </td>
+                    <td class='non-identifier'>
+                        {% if has_mobile %}
+                            <input type='button' class='btn btn-link verify_mb' value="{{_('Verify by registered phone')}}"
+                                   data-index='{{ nin }} {{ loop.index0 }}' name='verify_mb'>
+                        {% endif %}
+                    </td>
+                    <!-- Removed functionality temporary
+                        <td>
+                            <input type='button' class='btn btn-link' value="{{_('Remove')}}"
+                                data-index='{{ nin }} {{ loop.index0 }}' name='remove'>
+                        </td>
+                    -->
+                </tr>
+            {% endfor %}
+        {% endif %}
     {% endif %}
     </table>
   </div>


### PR DESCRIPTION
This fixes a regression in the "Confirm Identity"-tab where unverified NINs are still displayed, with the usual links to have them verified at MM or by phone, after a NIN have been marked as verified.