### PR TITLE
take SCRIPT_NAME into account when re-authenticating

### DIFF
--- a/eduiddashboard/middleware.py
+++ b/eduiddashboard/middleware.py
@@ -7,7 +7,7 @@ def reauthn_ts_tween_factory(handler, registry):
 
     def clean_reauthn_ts_from_session(request):
         response = handler(request)
-        path = request.get('PATH_INFO', '')
+        path = request.get('SCRIPT_NAME', '') + request.get('PATH_INFO', '')
         acs_path = request.route_path('saml2-acs')
         try:
             chp_path = request.route_path('password-change')


### PR DESCRIPTION
Reauthentication (needed to change password) was failing with a 400 when we had configured a SCRIPT_NAME. It was failing to recognize that we are in a view where we want to keep the re-authn timestamp.