### PR TITLE
Replace existing NIN on verification

### DIFF
--- a/eduiddashboard/tests/test_verify.py
+++ b/eduiddashboard/tests/test_verify.py
@@ -1,3 +1,5 @@
+import datetime
+
 from unittest import TestCase
 from eduid_userdb import User
 from eduid_userdb.testing import MOCKED_USER_STANDARD
@@ -373,7 +375,8 @@ class TestRemoveninFromUser(TestCase):
     def test_verify_existing_number(self):
         """ Verify an existing number on the test user """
         this = self.ninuser
-        _add_nin_to_user('0000', this)
+        now = datetime.datetime.utcnow()
+        _add_nin_to_user('0000', this, created_ts = now)
         expected = [{'number': '1111',
                      'verified': True,
                      'primary': True,
@@ -385,6 +388,8 @@ class TestRemoveninFromUser(TestCase):
                     {'number': '0000',
                      'verified': True,
                      'primary': False,
+                     'created_by': 'dashboard',
+                     'created_ts': now,
                      },
                     ]
         self.assertEqual(this.nins.to_list_of_dicts(), expected)

--- a/eduiddashboard/verifications.py
+++ b/eduiddashboard/verifications.py
@@ -182,7 +182,7 @@ def _remove_nin_from_user(nin, user):
     return user
 
 
-def _add_nin_to_user(new_nin, user):
+def _add_nin_to_user(new_nin, user, created_ts=None):
     """
     Add a NIN to a user.
     Part of set_nin_verified() above.
@@ -192,6 +192,7 @@ def _add_nin_to_user(new_nin, user):
                       application = 'dashboard',
                       verified = True,
                       primary = primary,
+                      created_ts = created_ts,
                       )
     # Remove the NIN from the user if it is already there
     try:

--- a/eduiddashboard/verifications.py
+++ b/eduiddashboard/verifications.py
@@ -18,7 +18,7 @@ from eduid_userdb.nin import Nin
 from eduid_userdb.mail import MailAddress
 from eduid_userdb.phone import PhoneNumber
 from eduid_userdb.element import DuplicateElementViolation
-from eduid_userdb.exceptions import UserOutOfSync
+from eduid_userdb.exceptions import UserOutOfSync, UserDBValueError
 from eduiddashboard.i18n import TranslationString as _
 from eduiddashboard.utils import get_unique_hash
 from eduiddashboard.utils import retrieve_modified_ts
@@ -193,10 +193,12 @@ def _add_nin_to_user(new_nin, user):
                       verified = True,
                       primary = primary,
                       )
+    # Remove the NIN from the user if it is already there
     try:
-        user.nins.add(new_nin_obj)
-    except DuplicateElementViolation:
-        user.nins.find(new_nin).is_verified = True
+        user.nins.remove(new_nin)
+    except UserDBValueError:
+        pass
+    user.nins.add(new_nin_obj)
 
 
 def _nin_verified_transaction_audit(request, reference):


### PR DESCRIPTION
This fixes a problem with verifying an existing NIN that was not
primary, when there were no other NINs in the list.

Also, it seems much more interesting to store which application it was
that _last_ verified a NIN (and when), rather than which one did it
first.